### PR TITLE
Tab Consistency

### DIFF
--- a/surt/handyurl.py
+++ b/surt/handyurl.py
@@ -203,7 +203,7 @@ class handyurl(object):
     def getURLString(self, surt=False, public_suffix=False):
 
         if None != self.opaque:
-			return self.opaque
+            return self.opaque
 
         if 'dns' == self.scheme:
             s = self.scheme + ':'   ###java version adds :// regardless of scheme


### PR DESCRIPTION
TabError: inconsistent use of tabs and spaces in indentation
